### PR TITLE
Package management - Ready for Alpha Release

### DIFF
--- a/usr/libexec/pi-web-agent/cgi-bin/toolkit/package_recommendations.py
+++ b/usr/libexec/pi-web-agent/cgi-bin/toolkit/package_recommendations.py
@@ -62,7 +62,7 @@ def main():
     view.output()
 
 def getDpkgInfo(pName, fieldName) :
-    bashCommand = "./apt-query " + pName + " " + fieldName
+    bashCommand = "apt-query " + pName + " " + fieldName
     output, errorcode = execute( bashCommand )
     if output == "" :
       return fieldName + " not available"

--- a/usr/libexec/pi-web-agent/cgi-bin/toolkit/recommendationsList.txt
+++ b/usr/libexec/pi-web-agent/cgi-bin/toolkit/recommendationsList.txt
@@ -8,6 +8,7 @@ mplayer
 mysql-client-core-5.1
 openjdk-7-jdk
 openjdk-7-jre
+openvpn
 perl
 php5-cli
 python


### PR DESCRIPTION
Used your script to execute the bash command to retrieve Description or LongDescription or Version of the package we want to display in the table(displaying verstion and short description atm). 

Removed high risk packages like apache2 and ssh. 
