### PR TITLE
Addition of flush calls to pi_iptables_api

### DIFF
--- a/usr/libexec/pi-web-agent/cgi-bin/toolkit/pi_iptables_api.py
+++ b/usr/libexec/pi-web-agent/cgi-bin/toolkit/pi_iptables_api.py
@@ -17,6 +17,9 @@ class IPTablesManagerAPI(IPTablesManager):
         return iptables_json
 
     def flushRules(self, chain):
+        if chain=="all":
+            chain = ""
+            
         command = "sudo iptables -F {chain_name}"
         out, exit_code = execute(command.format(chain_name = chain))
 


### PR DESCRIPTION
Added the API calls:
Flush specific chain : cgi-bin/toolkit/pi_iptables_api.py?flush={chain_name}
Flush all chains : cgi-bin/toolkit/pi_iptables_api.py?flush=all

The calls are implemented in the 'flushRules' method in the IPTablesManagerAPI class in 'pi_iptables_api.py'.
