### PR TITLE
Refactor/power commands with syscall

### DIFF
--- a/service/web/pkg/power_off.go
+++ b/service/web/pkg/power_off.go
@@ -1,7 +1,7 @@
 package api
 
 import (
-	shell "github.com/vaslabs/pi-web-agent/internal"
+	"syscall"
 )
 
 type power_off_response struct {
@@ -10,10 +10,12 @@ type power_off_response struct {
 }
 
 func System_Power_Off() power_off_response {
-	message, err := shell.RunSingle("poweroff")
+	err := syscall.Reboot(syscall.LINUX_REBOOT_CMD_POWER_OFF)
+	message := "Powering off"
 	exit_code := 0
-	if err == nil {
+	if err != nil {
 		exit_code = 1
+		message = err.Error()
 	}
 	return power_off_response{
 		Message:   message,
@@ -22,10 +24,12 @@ func System_Power_Off() power_off_response {
 }
 
 func System_Reboot() power_off_response {
-	message, err := shell.RunSingle("reboot")
+	err := syscall.Reboot(syscall.LINUX_REBOOT_CMD_RESTART)
+	message := "Rebooting"
 	exit_code := 0
-	if err == nil {
+	if err != nil {
 		exit_code = 1
+		message = err.Error()
 	}
 	return power_off_response{
 		Message:   message,

--- a/ui/pi-web-agent-app/src/app/live-info/live-info.component.ts
+++ b/ui/pi-web-agent-app/src/app/live-info/live-info.component.ts
@@ -19,7 +19,7 @@ export class LiveInfoComponent implements OnInit, OnDestroy {
       Id: '',
       Version_Codename: ''
     }
-  }
+  };
 
   constructor(private systemInfoService: SystemInfoService, private piControl: PiControlService) {
     this.systemInfo$ = this.piControl.eventSource().pipe(

--- a/ui/pi-web-agent-app/src/app/pi-control.service.ts
+++ b/ui/pi-web-agent-app/src/app/pi-control.service.ts
@@ -37,8 +37,8 @@ export class PiControlService implements OnDestroy {
   }
 
   ngOnDestroy(): void{
-    if (this.webSocketSubscription !==null){
-      this.webSocketSubscription.unsubscribe()
+    if (this.webSocketSubscription !== null){
+      this.webSocketSubscription.unsubscribe();
     }
   }
 

--- a/ui/pi-web-agent-app/src/app/websocket.service.ts
+++ b/ui/pi-web-agent-app/src/app/websocket.service.ts
@@ -12,7 +12,7 @@ export class WebsocketService {
   private messageStream: Observable<any>;
   constructor() {
     this.websocket = this.create();
-    this.messageStream = this.websocket.pipe(retryBackoff(1000), share())
+    this.messageStream = this.websocket.pipe(retryBackoff(1000), share());
   }
 
   private url(): string {


### PR DESCRIPTION
Currently the poweroff function inherits the priviledges of the gui since we are running this from the e.g. gnome-terminal and poweroff and reboot work without needing root priviledges as they inherit the gui ones (I think). However when it runs as a service this will not apply.

Go has also a linux syscall API that we can use instead of issuing shell commands which will dramatically decrease response times (although not a big deal for power management, having this paradigm in would be beneficial for later)